### PR TITLE
Fixed path to build artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - <<: *save_compile_cache
       - <<: *save_build
       - store_artifacts:
-          path: ~/igvc-firmware/build/igvc-firmware.bin
+          path: ~/igvc-firmware/build/bin/igvc-firmware-mbed.bin
   test:
     <<: *dir
     <<: *image


### PR DESCRIPTION
This PR fixes #12 by correcting the path to the build artifacts.

# How to test:
1. Check out the "compile" step for the circleci job for this PR
2. Go to the artifacts tab

Expectation: The `/igvc-firmware-mbed.bin` bin file is there